### PR TITLE
Fix example command

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -146,7 +146,7 @@ This step is only necessary if you want to have local jabber server.
 Install ejabberd using your package manager. In case of Archlinux execute as root:
 
 ----
-$ pacman -S ejabberd
+# pacman -S ejabberd
 ----
 
 Now, having server installed you have different ways to start it. If you want


### PR DESCRIPTION
Fix prompt character, usually when logged as root the prompt has a # char instead of a $ char
