### PR TITLE
Change wording on a recommendation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -171,8 +171,9 @@ systemctl start ejabberd
 In this case, if you want interact with server using _ejabberdctl_ command, you should
 change to ejabberd user (using `su - ejabberd`)
 
-I recommend setup empty password for ejabberd user for make easy access to it
-from your standard user, avoiding the the step of jump to root user.
+For example, I recommend to setup an empty password for ejabberd user. This will allow 
+you to switch to the ejabberd user without the need to remember another password or 
+using the root user first.
 
 
 Now, as _ejabberd_ user, create an user in ejabberd server:


### PR DESCRIPTION
Change the recommendation about using ejabberd with an empty
password, because the original explanation read weird.

Also maybe this explanation could be extended to talk about
more secure ways to call ejabberdctl commands
